### PR TITLE
Views created for rock and type

### DIFF
--- a/rockapi/views/__init__.py
+++ b/rockapi/views/__init__.py
@@ -1,1 +1,3 @@
 from .auth import login_user, register_user
+from .type_view import TypeView
+from .rock_view import RockView

--- a/rockapi/views/rock_view.py
+++ b/rockapi/views/rock_view.py
@@ -1,0 +1,41 @@
+from django.http import HttpResponseServerError
+from rest_framework import serializers, status
+from rest_framework.response import Response
+from rest_framework.viewsets import ViewSet
+from rockapi.models import Rock
+
+
+class RockView(ViewSet):
+    """Rock view set"""
+
+
+    def create(self, request):
+        """Handle POST operations
+
+        Returns:
+            Response -- JSON serialized instance
+        """
+
+        # You will implement this feature in a future chapter
+        return Response("", status=status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    def list(self, request):
+        """Handle GET requests for all items
+
+        Returns:
+            Response -- JSON serialized array
+        """
+        try:
+            rocks = Rock.objects.all()
+            serializer = RockSerializer(rocks, many=True)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        except Exception as ex:
+            return HttpResponseServerError(ex)
+
+
+class RockSerializer(serializers.ModelSerializer):
+    """JSON serializer"""
+
+    class Meta:
+        model = Rock
+        fields = ( 'id', 'name', 'weight', )

--- a/rockapi/views/type_view.py
+++ b/rockapi/views/type_view.py
@@ -1,0 +1,39 @@
+"""View module for handling requests for type data"""
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers, status
+from rockapi.models import Type
+
+
+class TypeView(ViewSet):
+    """Rock API types view"""
+
+    def list(self, request):
+        """Handle GET requests to get all types
+
+        Returns:
+            Response -- JSON serialized list of types
+        """
+
+        types = Type.objects.all()
+        serialized = TypeSerializer(types, many=True)
+        return Response(serialized.data, status=status.HTTP_200_OK)
+
+    def retrieve(self, request, pk=None):
+        """Handle GET requests for single type
+
+        Returns:
+            Response -- JSON serialized type record
+        """
+
+        rock_type = Type.objects.get(pk=pk)
+        serialized = TypeSerializer(rock_type)
+        return Response(serialized.data, status=status.HTTP_200_OK)
+
+
+class TypeSerializer(serializers.ModelSerializer):
+    """JSON serializer for types"""
+    class Meta:
+        model = Type
+        fields = ('id', 'label', )

--- a/rockproject/urls.py
+++ b/rockproject/urls.py
@@ -2,8 +2,13 @@ from django.contrib import admin
 from django.urls import include, path
 from rest_framework import routers
 from rockapi.views import register_user, login_user
+from django.conf.urls import include
+from rest_framework import routers
+from rockapi.views import TypeView, RockView
 
 router = routers.DefaultRouter(trailing_slash=False)
+router.register(r'rocks', RockView, 'rock')
+router.register(r'types', TypeView, 'type')
 
 urlpatterns = [
     path('', include(router.urls)),


### PR DESCRIPTION
Created view for rock, handling GET requests for all.  Placeholder code in place for POST request in future PR.

Created view for type, handling GET requests for all and single. 

Importing both views into the __init__ for the views package.

Routing views for rock and type in rockproject/urls.py