### PR TITLE
Expanding Foreign Keys and displaying objects instead of integers

### DIFF
--- a/rockapi/views/rock_view.py
+++ b/rockapi/views/rock_view.py
@@ -2,7 +2,7 @@ from django.http import HttpResponseServerError
 from rest_framework import serializers, status
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
-from rockapi.models import Rock
+from rockapi.models import Rock, Type
 
 
 class RockView(ViewSet):
@@ -32,10 +32,17 @@ class RockView(ViewSet):
         except Exception as ex:
             return HttpResponseServerError(ex)
 
+class RockTypeSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Type
+        fields = ('label',)
 
 class RockSerializer(serializers.ModelSerializer):
     """JSON serializer"""
 
+    type = RockTypeSerializer(many=False)
+
     class Meta:
         model = Rock
-        fields = ( 'id', 'name', 'weight', )
+        fields = ( 'id', 'name', 'weight', 'user', 'type', )

--- a/rockapi/views/rock_view.py
+++ b/rockapi/views/rock_view.py
@@ -3,6 +3,7 @@ from rest_framework import serializers, status
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 from rockapi.models import Rock, Type
+from django.contrib.auth.models import User
 
 
 class RockView(ViewSet):
@@ -38,10 +39,18 @@ class RockTypeSerializer(serializers.ModelSerializer):
         model = Type
         fields = ('label',)
 
+class RockUserSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = User
+        fields = ('first_name', 'last_name')
+
+
 class RockSerializer(serializers.ModelSerializer):
     """JSON serializer"""
 
     type = RockTypeSerializer(many=False)
+    user = RockUserSerializer(many=False)
 
     class Meta:
         model = Rock


### PR DESCRIPTION
Expanding the "Type" object under "Type" when requesting all rocks from the API:

- Created a RockTypeSerializer to serialize the received data into JSON string format using the Type model.
- Evaluating type as the RockTypeSerializer in the RockSerializer class.

Expanding the "User" object under "User" when requesting all rocks from the API:

- Created a RockUserSerializer to serialize the received data into JSON string format using the User model provided by Django.
- Evaluating user as the RockUserSerializer in the RockSerializer class, expanding first_name and last_name.