### PR TITLE
Delete function added to RockView, authenticating user

### DIFF
--- a/rockapi/views/rock_view.py
+++ b/rockapi/views/rock_view.py
@@ -44,6 +44,27 @@ class RockView(ViewSet):
             return Response(serializer.data, status=status.HTTP_200_OK)
         except Exception as ex:
             return HttpResponseServerError(ex)
+        
+    def destroy(self, request, pk=None):
+        """Handle DELETE requests for a single item
+
+        Returns:
+            Response -- 200, 404, or 500 status code
+        """
+        try:
+            rock = Rock.objects.get(pk=pk)
+            # Verify that the pk of the rock owner is the same pk as the authenticated user
+            if rock.user.id == request.auth.user.id:
+                rock.delete()
+                return Response(None, status=status.HTTP_204_NO_CONTENT)
+            else:
+                return Response({'message': 'You do not own that rock'}, status=status.HTTP_403_FORBIDDEN)
+
+        except Rock.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+        except Exception as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)   
 
 class RockTypeSerializer(serializers.ModelSerializer):
 


### PR DESCRIPTION
# Delete with user auth functioning in RockView
Added the delete method to the RockView, the method checks the user's token to only allow deletions of rocks that belong to the user.

## STEPS TO TEST

1. Pull the 'destroy' branch associated with this PR.
2. Start/Restart your debugger/JSON-Server
3. Open Postman
4. Prior to submitting a request, add an Authentication header with the value of "Token x", use the token(x) associated with your login.
5. Submit two separate DELETE requests to `http://localhost:8000/rocks/n`
- Provide a PK(n) for a rock you have created
- Provide a PK(n) for a rock you have no created
6. Verify response status & payload:
- On success: 
- On failure: Status 403 `{ "message": "You do not own that rock" }`