### PR TITLE
Filter conditional added to RocksView for user rocks

### DIFF
--- a/rockapi/views/rock_view.py
+++ b/rockapi/views/rock_view.py
@@ -34,12 +34,16 @@ class RockView(ViewSet):
 
     def list(self, request):
         """Handle GET requests for all items
-
+        
         Returns:
             Response -- JSON serialized array
         """
+        owner_only = self.request.query_params.get("owner", None)
         try:
             rocks = Rock.objects.all()
+            if owner_only is not None and owner_only == "current": #? Checks if '?owner=current' is in the parsed URL.
+                rocks = rocks.filter(user=request.auth.user) #? Filters rocks owned by the user.
+
             serializer = RockSerializer(rocks, many=True)
             return Response(serializer.data, status=status.HTTP_200_OK)
         except Exception as ex:


### PR DESCRIPTION
# Filter functionality added for filtering by current user
Added a conditional statement that checks the query_params in the URL for `owner`.  If `owner` returns `"current"`, the rocks are filtered to only include the owner's rocks.

## STEPS TO TEST

1. Pull the 'filter-query' branch associated with this PR.
2. Start/Restart your debugger/JSON-Server
3. Open your preferred API testing software
4. Prior to submitting a request, add an Authentication Header with the value of "Token x", use the token (x) associated with your login.
5. Submit a GET request to 'http://localhost:8000/rocks?owner=current' 
6. Verify that in the response only the rocks associated with that user token are displayed.